### PR TITLE
Fix failing tests

### DIFF
--- a/app/instance-initializers/global-instance.js
+++ b/app/instance-initializers/global-instance.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-blog-engine/instance-initializers/global-instance';
+export { default, initialize } from 'ember-blog-engine/instance-initializers/global-instance';

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,5 +1,8 @@
-import Resolver from '../../resolver';
-import config from '../../config/environment';
+// Use the resolver that the Engine is using
+import Resolver from 'ember-engines/resolver';
+
+// Use the Engine's config
+import config from 'ember-blog-engine/config/environment';
 
 const resolver = Resolver.create();
 


### PR DESCRIPTION
So there were two failing tests:
1. The instance-initializer test was failing because you didn't re-export the `initialize` function and so it couldn't be found when importing into the test.
2. The integration test was failing because your test resolver wasn't looking in the right place.
